### PR TITLE
Dropping legacy mode for Svelte

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,7 +26,7 @@ export default tseslint.config(
             },
             parserOptions: {
                 projectService: {
-                    allowDefaultProject: ["eslint.config.mjs"],
+                    allowDefaultProject: ["eslint.config.mjs", "svelte.config.js"],
                 },
             },
         },

--- a/src/lib/Counter.svelte
+++ b/src/lib/Counter.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-    let count = 0;
+    let count = $state(0);
     const increment = () => {
         count += 1;
     };
 </script>
 
-<button on:click={increment}>
+<button onclick={increment}>
     count is {count}
 </button>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,1 @@
+export default { compilerOptions: { runes: true } };


### PR DESCRIPTION
VS Code kept saying "legacy mode". Forcing "Rune mode" instead. Luckily eslint surfaces the same deprecation warnings.