### PR TITLE
Adding `make build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ build:
 ## Misc
 
 .PHONY: all
-all: _HELP = Run linters and unit tests
-all: test lint
+all: _HELP = Run linters and unit tests and builds
+all: test lint build
 
 .PHONY: clean
 clean: _HELP = Remove temporary files

--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,15 @@ format:
 	pnpm run lint:fix
 
 .PHONY: test
-test: _HELP = Run unit tests (SPECIFIC_TEST env var available)
+test: _HELP = Run unit tests
 test:
 	@echo NotImplemented: $@
 
 ## Development
 
-.PHONY: dev-chrome
-dev-chrome: _HELP = Open a Chrome instance with the extension installed
-dev-chrome:
+.PHONY: dev dev-chrome
+dev dev-chrome: _HELP = Open a Chrome instance with the extension installed
+dev dev-chrome:
 	pnpm run dev
 
 .PHONY: dev-firefox
@@ -46,17 +46,31 @@ dev-firefox: _HELP = Open a Firefox instance with the extension installed
 dev-firefox:
 	pnpm run dev:firefox --mv2
 
+## Build
+
+.PHONY: build
+build: _HELP = Build all packages
+build:
+	pnpm build
+	pnpm build:firefox
+	pnpm zip
+	pnpm zip:firefox
+
 ## Misc
+
+.PHONY: all
+all: _HELP = Run linters and unit tests
+all: test lint
 
 .PHONY: clean
 clean: _HELP = Remove temporary files
 clean:
-	rm -rfv .output/
+	rm -rfv .output/ .wxt/
 
 .PHONY: distclean
 distclean: _HELP = Remove temporary files including node_modules
 distclean: clean
-	rm -rf node_modules/ .wxt/
+	rm -rf node_modules/
 
 define MAKEFILE_HELP_AWK
 BEGIN {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "wxt";
 
 // See https://wxt.dev/api/config.html
 export default defineConfig({
-    srcDir: "src",
     manifestVersion: 3,
     modules: ["@wxt-dev/module-svelte"],
+    srcDir: "src",
 });


### PR DESCRIPTION
I kept running the pnpm command manually a lot, especially to regenerate the .wxt directory.

Moving removal of .wxt into `make clean` since build/dev will regenerate it. distclean is too expensive what with the removal of node_modules.

Sorting wxt.config.ts

Adding `make dev` shortcut.